### PR TITLE
Fix admin delete permission logic

### DIFF
--- a/forum_backend/controllers/comment_controller.go
+++ b/forum_backend/controllers/comment_controller.go
@@ -60,7 +60,9 @@ func DeleteComment(c fiber.Ctx) error {
 		return c.Status(404).JSON(fiber.Map{"error": "Comment not found"})
 	}
 
-	if comment.UserID != user.ID || userRole != "admin" {
+	// allow administrators to delete any comment
+	// users can only delete their own comments
+	if comment.UserID != user.ID && userRole != "admin" {
 		return c.Status(403).JSON(fiber.Map{"error": "You can only delete your own comments"})
 	}
 

--- a/forum_backend/controllers/post_controller.go
+++ b/forum_backend/controllers/post_controller.go
@@ -49,7 +49,9 @@ func DeletePost(c fiber.Ctx) error {
 		return c.Status(404).JSON(fiber.Map{"error": "Post not found"})
 	}
 
-	if post.UserID != user.ID || userRole != "admin" {
+	// allow administrators to delete any post
+	// users can only delete their own posts
+	if post.UserID != user.ID && userRole != "admin" {
 		return c.Status(403).JSON(fiber.Map{"error": "You can only delete your own posts"})
 	}
 


### PR DESCRIPTION
## Summary
- correct delete access checks for posts and comments

## Testing
- `go vet ./...`
- `go test ./...`
- `npm install`
- `npm run lint` *(fails: Interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_6840cee11a98832996dd7c242d54d5fb